### PR TITLE
README: Replace the license link to a more authoritative one

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ The AMD blog "[Empowering The Industry with Open System Firmware - AMD openSIL](
 
 ## License:
 
-The MIT License (MIT): https://rem.mit-license.org
+The MIT License (MIT): https://opensource.org/license/mit/


### PR DESCRIPTION
The old link seems to be someone's personal MIT license (with their own name, etc) web page. Replace it with opensource.org.