### PR TITLE
Issue #22: printing uninitialized variable DimmSpd

### DIFF
--- a/xPRF/Mem/xPrfMem.c
+++ b/xPRF/Mem/xPrfMem.c
@@ -366,7 +366,7 @@ GetPhysicalDimmInfoD5 (
   uint8_t                   Socket;
   uint8_t                   Channel;
   uint8_t                   Dimm;
-  uint8_t                   DimmSpd[SPD_BUFFER_SIZE];
+  uint8_t                   DimmSpd[SPD_BUFFER_SIZE] = {0,};
   SIL_STATUS                SilStatus;
   uint8_t                   IoWidth;
   uint16_t                  BusWidth;


### PR DESCRIPTION
DimmSpd is not initialized.  Printing DimmSpd in its uninitialized state might display garbage values or data that doesn't make sense.

This change updates xPrfMem.c to initialize the DimmSpd variable.