### PR TITLE
CCX AP launch fix

### DIFF
--- a/xUSL/CCX/Common/Ccx.c
+++ b/xUSL/CCX/Common/Ccx.c
@@ -197,7 +197,7 @@ InitializeCcxAndLaunchAps (
   uint8_t            ApicMode;
   uint32_t           ApicId;
   uint32_t           ApNumBfLaunch = 0x0;
-  volatile uint16_t  *ApSyncFlag = NULL;
+  volatile uint32_t  *ApSyncFlag = NULL;
   uint8_t            i = 0;
   SMU_IP2IP_API      *SmuApi;
   DF_IP2IP_API       *DfApi;
@@ -489,7 +489,7 @@ InitializeCcxAndLaunchAps (
       &MemoryContentCopySize,
       CcxConfigData
       );
-    ApSyncFlag = (volatile uint16_t *)(uintptr_t) ApLaunchGlobalData.AllowToLaunchNextThreadLocation;
+    ApSyncFlag = (volatile uint32_t *)(uintptr_t) ApLaunchGlobalData.AllowToLaunchNextThreadLocation;
   }
 
   CCX_TRACEPOINT(SIL_TRACE_INFO, "Launching APs\n");

--- a/xUSL/CCX/Common/Ccx.c
+++ b/xUSL/CCX/Common/Ccx.c
@@ -680,6 +680,7 @@ SIL_STATUS CcxClassSetInputBlk (void)
  * @brief Necessary register setting before launching next thread
  *
  */
+NASM_ABI
 void
 RegSettingBeforeLaunchingNextThread (
   volatile AMD_CCX_AP_LAUNCH_GLOBAL_DATA *ApLaunchGlobalData

--- a/xUSL/CCX/Common/Ccx.h
+++ b/xUSL/CCX/Common/Ccx.h
@@ -135,7 +135,7 @@ typedef struct {
   // as offset to this element is used in ApAsm nasm file.
   volatile uint32_t          ApSyncCount;                      ///< Do NOT change the offset of this variable
   // as offset to this element is used in ApAsm nasm file.
-  uint32_t                   AllowToLaunchNextThreadLocation; ///< Do NOT change the offset of this variable
+  volatile uint32_t          AllowToLaunchNextThreadLocation; ///< Do NOT change the offset of this variable
   // as offset to this element is used in ApAsm nasm file.
   uint32_t                   ApStackBasePtr;                  ///< Do NOT change the offset of this variable
   // as offset to this element is used in ApAsm nasm file.

--- a/xUSL/CCX/Common/Ccx.h
+++ b/xUSL/CCX/Common/Ccx.h
@@ -171,7 +171,8 @@ SIL_STATUS InitializeCcx (
 void CcxSetMca (void);
 void CcxInitializeC6 (CCXCLASS_INPUT_BLK *CcxInputBlock);
 void ApAsmCode (void);
-void RegSettingBeforeLaunchingNextThread (volatile AMD_CCX_AP_LAUNCH_GLOBAL_DATA *);
+NASM_ABI void RegSettingBeforeLaunchingNextThread (
+  volatile AMD_CCX_AP_LAUNCH_GLOBAL_DATA *ApLaunchGlobalData);
 NASM_ABI void ApEntryPointInC (
   volatile AMD_CCX_AP_LAUNCH_GLOBAL_DATA *ApLaunchGlobalData);
 void CcxSetMiscMsrs (


### PR DESCRIPTION
There was a mismatch of ApSyncFlag variable type, which could potentially cause improper memory access by the CPU when launching APs. Also, mark AllowToLaunchNextThreadLocation as volatile, since it is also being set by APs during their startup, to ensure the compiler does not optimize this variable.

RegSettingBeforeLaunchingNextThread called from assembly takes a parameter in the ECX/RCX. However, the function is missing MS ABI attribute. Modify the function declaration and definition to include the missing MS ABI.

Fixes issue: https://github.com/openSIL/openSIL/issues/28

With these changes it was possible to launch all threads on Gigabyte MZ33-AR1 with AMD EPYC 9015.