### PR TITLE
meson: fix boolean options to use proper bool instead of strings

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,5 @@
-option('coverity', type: 'boolean', value: 'false', description: 'Whether or not to do a coverity build')
-option('unit_test', type: 'boolean', value: 'false', description: 'CI should use this to enable/build the unit test executables.')
+option('coverity', type: 'boolean', value: false, description: 'Whether or not to do a coverity build')
+option('unit_test', type: 'boolean', value: false, description: 'CI should use this to enable/build the unit test executables.')
 option('PlatKcfg', type: 'string', value: 'Onyx_SilCfg', description: 'Filename of the platform specific Kconfig file.')
 option('PlatKcfgDir', type: 'string', value: 'configs', description: 'Dir of the platform specific Kconfig file.')
 


### PR DESCRIPTION
Since Meson 1.1, using 'true'/'false' strings for boolean options is deprecated. Replace them with native booleans.