### PR TITLE
Update accidentally concatenated words in `README.md`'s `table`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ The AMD blog “[Empowering The Industry with Open System Firmware – AMD openS
 
    * Present list of supported reference platforms is shown in the following table.
 
-     | MarketSegment | AMD ProcessorFamily Model | Firmware | Reference PlatformName |
-     |---------------|---------------------------|----------|------------------------|
-     | Server        | F19M10                    | UEFI     | Onyx                   |
+     | MarketSegment | AMD Processor Family Model | Firmware | Reference Platform Name |
+     |---------------|----------------------------|----------|-------------------------|
+     | Server        | F19M10                     | UEFI     | Onyx                    |
 
 ## Forthcoming items:
 


### PR DESCRIPTION
Remediates, by adding a space between words that were previously delimited by `<br>`s, an accidental F&R from [`pull/34/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60`](https://github.com/openSIL/openSIL/pull/34/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60). [^1] Apologies.

[^1]: [`pull/34/files#r2486932038`](https://github.com/openSIL/openSIL/pull/34/files#r2486932038)