### PR TITLE
README.md: Align Genoa POC README with Phoenix/Turin, scrub non-ASCII

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# AMD openSIL: Proof-of-Concept (POC)
+# AMD openSIL: Genoa Proof-of-Concept (POC)
 
-## About the project:
+Note that because this branch in this codebase is a proof-of-concept and is NOT for use in production firmware it is not eligible for bug bounty programs from AMD.
+
+## About the project
 
 The AMD open Silicon Initialization Library (openSIL) is a collection of C libraries which can be integrated into an x86 host firmware, by directly compiling source or by linking with static libraries.
 
@@ -8,37 +10,31 @@ AMD openSIL consists of three statically linked libraries; xSIM (x86 Silicon Ini
 
 Source for the libraries resides under [xSIM](xSIM), [xPRF](xPRF), and [xUSL](xUSL).
 
-Formal documentation is in final review and will be uploaded to the [GitHub project page](https://github.com/openSIL/openSIL/tree/master/Documentation) when available.
+The AMD blog "[Empowering The Industry with Open System Firmware - AMD openSIL](https://community.amd.com/t5/business/empowering-the-industry-with-open-system-firmware-amd-opensil/ba-p/599644)" provides a starting point to grasp the openSIL design goals.
 
-The AMD blog “[Empowering The Industry with Open System Firmware – AMD openSIL](https://community.amd.com/t5/business/empowering-the-industry-with-open-system-firmware-amd-opensil/ba-p/599644)” provides a starting point to grasp the openSIL design goals.
+## AMD openSIL open-source projected roadmap
 
-## AMD openSIL open-source projected roadmap: 
+### Evaluation Only Phases (no support for production implementations)
 
-   ### Evaluation Only Phases (no support for production implementations):
-   
-   1. Phase I   – Internal POC (complete).
-   
-   2. Phase II  – AMD openSIL POC open-sourced for evaluation on AMD 4th Gen EPYC&trade; based CRB (complete: this source).
-   
-   3. Phase III – POC openSIL POC open-sourced, trending Q4 2024.
+1. Phase I   - Internal POC (complete).
+2. Phase II  - AMD openSIL POC open-sourced for evaluation on AMD 4th Gen EPYC&trade; based CRB (complete: this source).
+3. Phase III - AMD openSIL POCs open-sourced for additional AMD platforms (complete).
 
-   ### Production Phase:
+### Production Phase
 
-   4. Phase IV: – AMD openSIL POR with UEFI Host FW trending 2026.
+1. Phase IV  - AMD openSIL POR with UEFI Host FW trending 2026.
 
-## Getting Started:
+## Getting Started
 
 1. Clone Repository:
 
    1. Establish your GitHub user account and your SSH keys (details are beyond this doc)
-
    2. Open a command/terminal window
+   3. Run git to obtain the project:
 
-   3. Run `git` to obtain the project:
-
-       ```sh
-       git clone git@github.com:openSIL/openSIL.git
-       ```
+      ```sh
+      git clone git@github.com:openSIL/openSIL.git
+      ```
 
 2. Establish the project environment variables.
 
@@ -56,41 +52,36 @@ The AMD blog “[Empowering The Industry with Open System Firmware – AMD openS
       python %PYTHONPATH%\menuconfig.py Kconfig
       ```
 
-4. Build openSIL Libraries:
-
-   * The AMD openSIL library build is performed using 'Meson build', an open source python tool (see GitHub).  Several targets allow a focused build for xUSL, xSIM, xPRF or openSIL(xUSL + xSIM + XPRF) static libraries. AMD openSIL specific Meson build documentation is not yet available.
-
-   * The project can be built for 32bit and/or 64bit compilation and static libraries.
+4. Configure toolchains
 
    * The project supports both the GNU/GCC or LLVM/clang tool chain and the Microsoft Visual C tool chain. Generally it is recommended to use the latest versions of these tool chains.
-   Specific versions being used today (June 2023) are:
-
-     * GCC – v10.2.0
-
-     * llvm/clang – v10.0
-
+     Specific versions being used today (June 2023) are:
+     * GCC - v10.2.0
+     * llvm/clang - v10.0
      * MSVC v19.00.24210  (Visual Studio 2019)
 
-5. Integrate with Host Firmware:
+5. Build openSIL Libraries:
 
-   * AMD has a separate repository (“`opensil-uefi-interface`”) for helping customers integrate openSIL with previous UEFI-AGESA installations.  Please contact your AMD representative for more information.
+   * The AMD openSIL library build is performed using 'Meson build', an open source python tool (see GitHub).  Several targets allow a focused build for xUSL, xSIM, xPRF or openSIL(xUSL + xSIM + XPRF) static libraries. AMD openSIL specific Meson build documentation is not yet available.
+   * The project can be built for 32bit and/or 64bit compilation and static libraries.
 
-6. Test Host Firmware on reference platform
+6. Integrate with Host Firmware:
+
+   * AMD has a separate repository ("opensil-uefi-interface") for helping customers integrate openSIL with previous UEFI-AGESA installations.  Please contact your AMD representative for more information.
+
+7. Test Host Firmware on reference platform
 
    * All AMD openSIL testing has been performed on an AMD reference platform (Onyx CRB).
-
    * Present list of supported reference platforms is shown in the following table.
 
-     | MarketSegment | AMD Processor Family Model | Firmware | Reference Platform Name |
-     |---------------|----------------------------|----------|-------------------------|
-     | Server        | F19M10                     | UEFI     | Onyx                    |
+   | Market Segment | AMD Processor Family Model | Firmware | Reference Platform Name |
+   | -------------- | -------------------------- | -------- | ----------------------- |
+   | Server         | F19M10                     | UEFI     | Onyx                    |
 
-## Forthcoming items:
+## Copyright
 
-   * Formal documentation to be published to this repository.
+All code in this codebase is Copyright Advanced Micro Devices unless otherwise noted.
 
-   * Continuous integration (CI) tools will be implemented as a pre-requisite to merging pull requests.
+## License
 
-## License:
-
-The MIT License (MIT): https://opensource.org/license/mit/
+The MIT License (MIT): <https://opensource.org/license/mit/>


### PR DESCRIPTION
Clean up the Genoa POC README to generally match the README files for the newer phoenix_poc and turin_poc releases.

Content changes:
* Add the bug-bounty eligibility disclaimer.
* Rework the roadmap section.
* Split the "Build openSIL Libraries" step into a new "Configure toolchains" step (step 4) followed by the build step (step 5), to match the structure used on the other POC branches.
* Remove the stale "Formal documentation is in final review and will be uploaded to the GitHub project page when available." paragraph.
* Drop the "Forthcoming items" section. Its two bullets (formal documentation and CI) were aspirational statements that have not materialized and are not specific to this Genoa POC branch.
* Add a "Copyright" section with the standard AMD notice.
* Reformat the reference-platform table.
* Update all Non-ASCII characters to ASCII versions.
* Formatting / markdown lint fixes: