### PR TITLE
README.md: Retitle for Phoenix, add bug-bounty/copyright, fix lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# AMD openSIL: Proof-of-Concept (POC)
+# AMD openSIL: Phoenix Proof-of-Concept (POC)
 
+Note that because this branch in this codebase is a proof-of-concept and is NOT for use in production firmware it is not eligible for bug bounty programs from AMD.
 
-## About the project:
+## About the project
 
 The AMD open Silicon Initialization Library (openSIL) is a collection of C libraries which can be integrated into an x86 host firmware, by directly compiling source or by linking with static libraries.
 
@@ -9,81 +10,81 @@ AMD openSIL consists of three statically linked libraries; xSIM (x86 Silicon Ini
 
 Source for the libraries resides under [xSIM](xSIM), [xPRF](xPRF), and [xUSL](xUSL).
 
-Formal documentation is in final review and will be uploaded to the [GitHub project page](https://github.com/openSIL/openSIL/tree/master/Documentation) when available.<br>
-The AMD blog "[Empowering The Industry with Open System Firmware - AMD openSIL](https://community.amd.com/t5/business/empowering-the-industry-with-open-system-firmware-amd-opensil/ba-p/599644)" provides a starting point to grasp the openSIL design goals.<br><br>
+The AMD blog "[Empowering The Industry with Open System Firmware - AMD openSIL](https://community.amd.com/t5/business/empowering-the-industry-with-open-system-firmware-amd-opensil/ba-p/599644)" provides a starting point to grasp the openSIL design goals.
 
+## AMD openSIL open-source projected roadmap
 
-## AMD openSIL open-source projected roadmap:
-   ### Evaluation Only Phases (no support for production implementations):
-   1. Phase I   - Internal POC (complete).
-   2. Phase II  - AMD openSIL POC open-sourced for evaluation on AMD 4th Gen EPYC&trade; based CRB.
-   3. Phase III - POC openSIL POC open-sourced, Q4 2024.
-   ### Production Phase:
-   4. Phase IV: - AMD openSIL POR with UEFI Host FW trending 2026.<br><br>
+### Evaluation Only Phases (no support for production implementations)
 
+1. Phase I   - Internal POC (complete).
+2. Phase II  - AMD openSIL POC open-sourced for evaluation on AMD 4th Gen EPYC&trade; based CRB (complete).
+3. Phase III - AMD openSIL POC open-sourced for evaluation on AMD Phoenix based CRB (complete: this source).
 
-## Getting Started:
+### Production Phase
+
+1. Phase IV  - AMD openSIL POR with UEFI Host FW trending 2026.
+
+## Getting Started
 
 1. Clone Repository:
 
    1. Establish your GitHub user account and your SSH keys (details are beyond this doc)
    2. Open a command/terminal window
    3. Run git to obtain the project:
-       ```> git clone git@github.com:openSIL/openSIL.git```<br><br>
 
+      ```sh
+      git clone -b phoenix_poc git@github.com:openSIL/openSIL.git
+      ```
 
 2. Establish the project environment variables.
 
-   * You will find a shell/cmd file (SetSilEnv) in the 'util' directory for this purpose.<br><br>
-
+   * You will find a shell/cmd file (SetSilEnv) in the 'util' directory for this purpose.
 
 3. Configure your project
 
-   * This release of the AMD openSIL libraries supports AMD Phoenix processor; on the Mayan and Birman CRBs only
+   * This release of the AMD openSIL libraries supports the AMD Phoenix processor on the Mayan and Birman CRBs only.
 
    * The openSIL project uses the python version of the Kconfig tool for this purpose. (See GitHub Kconfiglib).
 
    * Run the interactive configuration UI:
-      ```> python %PYTHONPATH%\menuconfig.py Kconfig```<br><br>
 
+      ```cmd
+      python %PYTHONPATH%\menuconfig.py Kconfig
+      ```
 
 4. Configure toolchains
 
-   *  The project supports both the GNU/GCC toolchain and the Microsoft Visual C toolchain. Generally it is recommended to use the latest versions of these toolchains. <br />Specific versions being used today (September 2024) are:
-     *  GCC - 13.2.0
-     *  MSVC v19.40.33812  (Visual Studio 2022)
-     *  NASM 2.15.05 (Must be at least 2.15.05)
-     *  MESON 1.5.1 (Must be at least 1.1.0)
-
+   * The project supports both the GNU/GCC toolchain and the Microsoft Visual C toolchain. Generally it is recommended to use the latest versions of these toolchains.
+     Specific versions being used today (September 2024) are:
+     * GCC - 13.2.0
+     * MSVC v19.40.33812  (Visual Studio 2022)
+     * NASM 2.15.05 (Must be at least 2.15.05)
+     * MESON 1.5.1 (Must be at least 1.1.0)
 
 5. Build openSIL Libraries:
 
-   *  openSIL library build is performed using 'Meson build', an open source python tool (see GitHub).  Several targets allow a focused build for xUSL, xSIM, xPRF or openSIL(xUSL + xSIM + XPRF) static libraries. See the Meson_Build_Notes file under the Documentation folder.
+   * openSIL library build is performed using 'Meson build', an open source python tool (see GitHub).  Several targets allow a focused build for xUSL, xSIM, xPRF or openSIL(xUSL + xSIM + XPRF) static libraries. See the Meson_Build_Notes file under the Documentation folder.
    * The project can be built for 32bit and/or 64bit compilation and static libraries.
-
 
 6. Integrate with Host Firmware:
 
-   * AMD has a separate repository ("opensil-uefi-interface" ) for helping customers integrate openSIL with previous UEFI-AGESA installations. Please contact your AMD representative.
+   * AMD has a separate repository ("opensil-uefi-interface") for helping customers integrate openSIL with previous UEFI-AGESA installations. Please contact your AMD representative.
    * AMD is also adding openSIL support into the coreboot.org repositories.
-
 
 7. Test Host Firmware on reference platform
 
-   * All AMD openSIL testing has been performed on an AMD reference platform (Mayan CRB).
+   * All AMD openSIL testing has been performed on AMD reference platforms (Mayan and Birman CRBs).
    * Present list of supported reference platforms is shown in the following table.
 
-| Market<br>Segment   | AMD Processor<br> Family Model   | Firmware | Reference<br> Platform Name   |
-| ------------------- | -------------------------------- | -------- | ----------------------------- |
-| Client              | F19M70                           | UEFI     | Mayan                         |
-| Client              | F19M70                           | UEFI     | Birman                        |
+   | Market Segment | AMD Processor Family Model | Firmware | Reference Platform Name |
+   | -------------- | -------------------------- | -------- | ----------------------- |
+   | Client         | F19M70                     | UEFI     | Mayan                   |
+   | Client         | F19M70                     | UEFI     | Birman                  |
 
+## Copyright
 
-## Forthcoming items:
+All code in this codebase is Copyright Advanced Micro Devices unless otherwise noted.
 
-   * Formal documentation to be published to this repository.
-   * Continuous integration (CI) tools will be implemented as a pre-requisite to merging pull requests.
+## License
 
-## License:
-
-The MIT License (MIT): https://opensource.org/license/mit/
+The MIT License (MIT): <https://opensource.org/license/mit/>


### PR DESCRIPTION
Adjust the README to describe this branch as the Phoenix POC and bring its formatting in line with markdownlint defaults.

Content changes:

* Retitle to "AMD openSIL: Phoenix Proof-of-Concept (POC)".
* Add the bug-bounty eligibility disclaimer .
* Rework the roadmap so Phase II (Genoa POC) is marked complete and Phase III now describes the Phoenix POC (this source).
* Reword the Phoenix/Mayan/Birman sentence to fix the misplaced semicolon and missing period.
* Remove the stray space in ("opensil-uefi-interface" ).
* Update the platform-testing sentence to cover both Mayan and Birman, matching the reference-platform table.
* Add "-b phoenix_poc" to the git clone command so users land on the Phoenix POC source this README describes (the repo default branch is genoa_poc).
* Add a "Copyright" section with the standard AMD notice.
* Remove the stale "Formal documentation is in final review and will be uploaded to the GitHub project page when available." paragraph.
* Drop the "Forthcoming items" section. Its two bullets (formal documentation and CI) were aspirational statements that have not materialized and are not specific to this Phoenix POC branch.
* Update all Non-ASCII characters to ASCII versions.
* Formatting / markdown lint fixes.