### PR TITLE
Fix uninitialized TOM2_LOWER_REG written to hardware in NbioSet

### DIFF
--- a/xUSL/NBIO/IOD/NbioTopMem.c
+++ b/xUSL/NBIO/IOD/NbioTopMem.c
@@ -50,7 +50,7 @@ NbioSetTopOfMemory (void)
    TOP_OF_DRAM.Value = xUSLSmnRead (GnbHandle->Address.Address.Segment,
        GnbHandle->Address.Address.Bus,
        SMN_IOHUB0NBIO0_NB_TOP_OF_DRAM_SLOT1_ADDRESS);
-   TOP_OF_DRAM.Value = xUSLSmnRead (GnbHandle->Address.Address.Segment,
+   TOM2_LOWER_REG.Value = xUSLSmnRead (GnbHandle->Address.Address.Segment,
        GnbHandle->Address.Address.Bus,
        SMN_IOHUB0NBIO0_NB_LOWER_TOP_OF_DRAM2_ADDRESS);
   TOM2_UPPER_REG.Value = xUSLSmnRead (GnbHandle->Address.Address.Segment,


### PR DESCRIPTION
## What

`NbioSetTopOfMemory()` reads the `NB_LOWER_TOP_OF_DRAM2` register into the wrong variable. The result is assigned to `TOP_OF_DRAM.Value` (a copy of the line above, with only the SMN address changed) instead of `TOM2_LOWER_REG.Value`.

```c
TOP_OF_DRAM.Value    = xUSLSmnRead(..., SMN_..._NB_TOP_OF_DRAM_SLOT1_ADDRESS);
TOP_OF_DRAM.Value    = xUSLSmnRead(..., SMN_..._NB_LOWER_TOP_OF_DRAM2_ADDRESS); // wrong LHS
TOM2_UPPER_REG.Value = xUSLSmnRead(..., SMN_..._NB_UPPER_TOP_OF_DRAM2_ADDRESS);
```

## Impact

- `TOM2_LOWER_REG` is never initialized from hardware. It is written only inside `if (GnbTom2 != 0)`, and only its `LOWER_TOM2`/`ENABLE` fields. Its full `.Value` is then written unconditionally to `NB_LOWER_TOP_OF_DRAM2` on every NBIO instance. On the `GnbTom2 == 0` path (`SYS_CFG[MtrrTom2En]` clear, or `TOP_MEM2 == 0`) the whole value - including the `ENABLE` bit - is an indeterminate stack value; otherwise the reserved bits are. Consuming it yields an indeterminate value (undefined behavior when consumed).
- The `TOP_OF_DRAM_SLOT1` read on the previous line is discarded. `TOP_OF_DRAM`'s later RMW only rewrites bits 31:23, so the remaining bits written back to the SLOT1 register come from the wrong register.

## Fix

```diff
-   TOP_OF_DRAM.Value = xUSLSmnRead (GnbHandle->Address.Address.Segment,
+   TOM2_LOWER_REG.Value = xUSLSmnRead (GnbHandle->Address.Address.Segment,
        GnbHandle->Address.Address.Bus,
        SMN_IOHUB0NBIO0_NB_LOWER_TOP_OF_DRAM2_ADDRESS);
```

One-line change to a local's assignment; signature, control flow, and return are unchanged. It makes `TOM2_LOWER_REG` follow the same read-modify-write pattern as `TOM2_UPPER_REG`, and matches the function's own write-back that sends `TOM2_LOWER_REG.Value` to this register. It cannot regress the working cases: on `GnbTom2 == 0` the register's current value is simply written back unchanged.

## Reachability

`InitializeSiTp1` → `xSimInitializeIps` → `InitializeNbioTp1` → `NbioSetTopOfMemory`. Registered as the NBIO Timepoint-1 handler in `IpBlkListF19M10Tp1.c`.

## Verification

- clang static analyzer flags it with default checkers (`core.CallAndMessage`, "uninitialized value") at `NbioTopMem.c:108` (the `NB_LOWER_TOP_OF_DRAM2` write) and `:98` (trace) on the `GnbTom2 == 0` path. Reproduce over the project's meson/clang build: the checker needs the build's include paths. The warning clears after the fix.
- Compiles cleanly with the project's meson/clang build.

## Scope

Correctness/UB fix. Practical hardware impact is configuration-dependent (worst case is the `GnbTom2 == 0` path); **this does not claim to resolve a specific observed boot failure.**