### PR TITLE
xUSL/Mpio/Brh: make hotplug ports visible when no link trained

### DIFF
--- a/xUSL/Mpio/Brh/MpioPortVisibilityBrh.c
+++ b/xUSL/Mpio/Brh/MpioPortVisibilityBrh.c
@@ -96,7 +96,11 @@ MpioEnablePortBrh (
 
   while (Engine != NULL) {
     Wrapper = (PCIe_WRAPPER_CONFIG *) NbioIp2Ip->PcieConfigGetParent(DESCRIPTOR_ALL_WRAPPERS, &(Engine->Header));
-    if (Engine->InitStatus == INIT_STATUS_PCIE_TRAINING_SUCCESS) {
+    if (PcieConfigCheckPortStatus(Engine, INIT_STATUS_PCIE_TRAINING_SUCCESS) ||
+        PcieConfigCheckPortStatus(Engine, INIT_STATUS_PCIE_PORT_ALWAYS_EXPOSE) ||
+        (PcieConfigIsPcieEngine(Engine) && PcieConfigIsEngineAllocated(Engine) &&
+         (Engine->Type.Port.PortData.LinkHotplug != PcieHotplugDisabled) &&
+         (Engine->Type.Port.PortData.LinkHotplug != PcieHotplugInboard))) {
       MPIO_TRACEPOINT(SIL_TRACE_INFO,
         "%a Enabling port %d, RBIndex %d, Wrapper %d\n",
         Engine->Type.Port.LogicalBridgeId,


### PR DESCRIPTION
MpioEnablePortBrh needs to make hotplug-capable ports visible to the OS as otherwise hot-plugging a device into a port not occupied on boot won't work. This is even documented in the function doc comment, but was not implemented. PORT_ALWAYS_EXPOSE was also unhandled and a strict-equality check was used instead of the bitfield helper for TRAINING_SUCCESS. Fix all of these while in there.

This has been validated on an internal Turin platform.