### PR TITLE
xUSL/Mpio/Common: fix end-of-list NULL deref

### DIFF
--- a/xUSL/Mpio/Common/MpioPcie.c
+++ b/xUSL/Mpio/Common/MpioPcie.c
@@ -204,9 +204,11 @@ SwapLogicalBridgeId (
       EngineList->Type.Port.LogicalBridgeId = Engine->Type.Port.LogicalBridgeId;
     }
     EngineList = (PCIe_ENGINE_CONFIG *) PcieConfigGetNextTopologyDescriptor(EngineList, DESCRIPTOR_TERMINATE_TOPOLOGY);
-    TempWrapper = (PCIe_WRAPPER_CONFIG *) NbioIp2Ip->PcieConfigGetParent(DESCRIPTOR_ALL_WRAPPERS,
-      &(EngineList->Header)
-      );
+    if (EngineList != NULL) {
+      TempWrapper = (PCIe_WRAPPER_CONFIG *) NbioIp2Ip->PcieConfigGetParent(DESCRIPTOR_ALL_WRAPPERS,
+        &(EngineList->Header)
+        );
+    }
   }
   Engine->Type.Port.LogicalBridgeId = NewBdgIdx;
 


### PR DESCRIPTION
PcieConfigGetNextTopologyDescriptor returns NULL once there are no more descriptors. But the loop condition only checks at the start, so this then calls PcieConfigGetParent with a NULL-offset pointer. Only call that function if there is another descriptor.

This has been validated on an internal Turin platform.