### PR TITLE
Kconfig.SoC: Fix syntax error

### DIFF
--- a/Kconfig.SoC
+++ b/Kconfig.SoC
@@ -25,7 +25,7 @@ source "Kconfig.Skt"
 # Several SoCs may use the same IP-version
 
 config SOC_F1AM00
-    boolean "F1AM00 (Turin) Support"
+    bool "F1AM00 (Turin) Support"
     select HAVE_SOC_COMMON
     select HAVE_DF_DFX
     select HAVE_CCX_ZEN5


### PR DESCRIPTION
When attempting to use coreboot's Kconfig utility to produce openSIL config, an syntax error occurs on the boolean option. Proper syntax is bool.